### PR TITLE
Feat/Batched communication

### DIFF
--- a/Assets/Scripts/Managers/CommunicatorManager.cs
+++ b/Assets/Scripts/Managers/CommunicatorManager.cs
@@ -184,12 +184,6 @@ public static class CommunicatorManager
         var dicActions = Communicator?.GetActionsForBrain(brainName);
         return dicActions ?? new Dictionary<int, ActionBuffers>();
     }
-
-    public static ActionBuffers GetAction(string brainName, int agentId)
-    {
-        var actions = Communicator?.GetActions(brainName, agentId);
-        return actions ?? ActionBuffers.Empty;
-    }
 }
 }
 

--- a/Assets/Scripts/Managers/CommunicatorManager.cs
+++ b/Assets/Scripts/Managers/CommunicatorManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Unity.Collections;
 using Unity.MLAgents;
 using Unity.MLAgents.Actuators;
 using Unity.MLAgents.Sensors;
@@ -179,9 +180,9 @@ public static class CommunicatorManager
         Communicator.DecideBatch();
     }
     
-    public static Dictionary<int, ActionBuffers> GetActionsForBrain(string brainName)
+    public static Dictionary<int, ActionBuffers> GetActionsForBrain(FixedString32Bytes brainName)
     {
-        var dicActions = Communicator?.GetActionsForBrain(brainName);
+        var dicActions = Communicator?.GetActionsForBrain(brainName.ToString());
         return dicActions ?? new Dictionary<int, ActionBuffers>();
     }
 }

--- a/Assets/Scripts/Systems/DecideActionSystem.cs
+++ b/Assets/Scripts/Systems/DecideActionSystem.cs
@@ -16,18 +16,20 @@ namespace EcsTraining
         protected override void OnUpdate()
         {
             _uniqueBrainNames.Clear();
-            CommunicatorManager.DecideAction();
             
-            foreach (var brain in SystemAPI.Query<RefRO<BrainSimple>>())
+            foreach (var (brain, agent) in SystemAPI.Query<RefRO<BrainSimple>, RefRW<AgentEcs>>())
             {
+                if(!agent.ValueRO.RequestDecision) continue;
                 _uniqueBrainNames.Add(brain.ValueRO.FullyQualifiedBehaviorName.Value);
+                agent.ValueRW.RequestDecision = false;
             }
 
             if (_uniqueBrainNames.Count == 0) return;
             
+            CommunicatorManager.DecideAction();
+            
             foreach (string brainName in _uniqueBrainNames)
             {
-                
                 var actionsForThisBrain = CommunicatorManager.GetActionsForBrain(brainName);
                 if (actionsForThisBrain == null || actionsForThisBrain.Count == 0) continue;
                 

--- a/Assets/Scripts/Systems/ExternalCommunicatorSystem.cs
+++ b/Assets/Scripts/Systems/ExternalCommunicatorSystem.cs
@@ -63,7 +63,6 @@ namespace EcsTraining
                 
                 agent.ValueRW.Reward = 0f;
                 agent.ValueRW.GroupReward = 0f;
-                agent.ValueRW.RequestDecision = false;
             }
         }
     }


### PR DESCRIPTION
### **User description**
Communicator only triggered when there is at least one agent requesting a decision


___

### **PR Type**
Enhancement


___

### **Description**
- Trigger communication only when agents request a decision.

- Optimize action lookups by batching per brain.

- Relocate `RequestDecision` flag management to `DecideActionSystem`.

- Remove unused `GetAction` method from `CommunicatorManager`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph AgentBehavior
      A["Agent sets RequestDecision = true"]
  end
  subgraph DecideActionSystem
      B["Collect agents with RequestDecision"]
      C{"Any requests?"}
      D["Call CommunicatorManager.DecideAction()"]
      E["Fetch actions per brain & distribute"]
      F["Reset RequestDecision flag"]
  end
  A --> B
  B --> C
  C -- "Yes" --> D
  C -- "No" --> G[Skip Communication]
  D --> E
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommunicatorManager.cs</strong><dd><code>Remove unused per-agent action retrieval method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Assets/Scripts/Managers/CommunicatorManager.cs

<ul><li>Removed the <code>GetAction</code> method, which retrieved actions for a single <br>agent.<br> <li> The system now relies on the <code>GetActionsForBrain</code> method for batched <br>action retrieval.</ul>


</details>


  </td>
  <td><a href="https://github.com/zelcam4ever/ECS_LearningEnviroment_Dev/pull/4/files#diff-4b03da7339caf7c3ba4215bb25e20a79d8b9429d6412c9f59ff6a507209e6cbe">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DecideActionSystem.cs</strong><dd><code>Implement conditional communication based on agent decision requests</code></dd></summary>
<hr>

Assets/Scripts/Systems/DecideActionSystem.cs

<ul><li>Triggers <code>CommunicatorManager.DecideAction()</code> only when at least one <br>agent requests a decision.<br> <li> Gathers unique brain names before fetching actions to improve <br>performance.<br> <li> Resets the <code>RequestDecision</code> flag for agents after processing their <br>request.<br> <li> Adds a call to <code>Dependency.Complete()</code> to ensure proper resource <br>deallocation.</ul>


</details>


  </td>
  <td><a href="https://github.com/zelcam4ever/ECS_LearningEnviroment_Dev/pull/4/files#diff-78a573de22f8bc08dbbaba35d1be4978b7e4b4bfed9c85e8eedb6d5d3dc34c77">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ExternalCommunicatorSystem.cs</strong><dd><code>Relocate `RequestDecision` flag reset logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Assets/Scripts/Systems/ExternalCommunicatorSystem.cs

<ul><li>Removed the logic for resetting the <code>RequestDecision</code> flag.<br> <li> This responsibility has been moved to the <code>DecideActionSystem</code> which <br>consumes the flag.</ul>


</details>


  </td>
  <td><a href="https://github.com/zelcam4ever/ECS_LearningEnviroment_Dev/pull/4/files#diff-76047f9f14d1ae81eca62648a334bafd4c5d1870eace9dfda5c9baf95f1efe34">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

